### PR TITLE
Add editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+indent_style = tab
+charset = utf-8
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+charset = utf-8
+trim_trailing_whitespace = true


### PR DESCRIPTION
This ensures all text editors and IDEs share the same basic config when editing the source code of Rose.

Addition of a clang-format file should also be considered.