### PR TITLE
Fix some indentation in rose.c

### DIFF
--- a/rose.c
+++ b/rose.c
@@ -8,8 +8,8 @@ guint xid;
 void setatom(int a, const char *v)
 {
 	XChangeProperty(dpy, xid,
-									atoms[a], atoms[AtomUTF8], 8, PropModeReplace,
-									(unsigned char *)v, strlen(v) + 1);
+		atoms[a], atoms[AtomUTF8], 8, PropModeReplace,
+		(unsigned char *)v, strlen(v) + 1);
 	XSync(dpy, False);
 }
 


### PR DESCRIPTION
I just noticed a couple lines were indented like a dozen times, it doesn't look intentional as I don't see any other examples of that in the file. Feel free to ignore and close if it was indeed intentional.