### PR TITLE
use `execlp` instead of `execvp`

### DIFF
--- a/rose.c
+++ b/rose.c
@@ -128,8 +128,7 @@ void rose_download(char *uri)
 	int id = fork();
 	if (id == 0) {
 		setsid();
-		char *argv[] = {"/bin/sh", "-c", "\"aria2c \\", uri, "\"", NULL};
-		execvp("/bin/sh", argv);
+		execlp("aria2c", "aria2c", uri, NULL);
 		perror(" failed");
 		exit(1);
 	}


### PR DESCRIPTION
- Don't use `execvp` if `argv` is known in advance, `execlp` is a lot cleaner imho.
- Why spawn a shell to run aria2c? (Is there any reason behind that?) Just spawn aria2c.

P.S.: When is `rose_download(char)` triggered?