### PR TITLE
use `snprintf` instead of `sprintf`

### DIFF
--- a/rose.c
+++ b/rose.c
@@ -1,4 +1,5 @@
 #define _XOPEN_SOURCE 500
+#define _POSIX_C_SOURCE 200112
 
 #include <webkit2/webkit2.h>
 

--- a/rose.c
+++ b/rose.c
@@ -166,7 +166,7 @@ static RoseWebview *rose_webview_new(void)
 
 	if (!options[CACHE] && privacy[CACHING]) {
 		const char *HOME = getenv("HOME");
-		size_t bufsiz = sizeof(char) * (strlen(HOME) + 32) + 1;
+		size_t bufsiz = strlen(HOME) + 33;
 		char *buf = calloc(1, bufsiz);
 
 		snprintf(buf, bufsiz - 1, "%s/.cache/rose/", HOME);
@@ -245,7 +245,7 @@ static void append_history(const char *uri)
 {
 		char *cookiefile;
 		FILE *cookie;
-		size_t bufsiz = sizeof(char) * (strlen(options[CACHE]) + 32) + 1;
+		size_t bufsiz = strlen(options[CACHE]) + 33;
 		cookiefile= calloc(1, bufsiz);
 		snprintf(cookiefile, bufsiz - 1, "%s/history", options[CACHE]);
 		cookie = fopen(cookiefile, "a");

--- a/rose.c
+++ b/rose.c
@@ -1,3 +1,5 @@
+#define _XOPEN_SOURCE 500
+
 #include <webkit2/webkit2.h>
 
 #define LENGTH(x) (int)(sizeof(x) / sizeof(x[0]))
@@ -104,7 +106,7 @@ static void load_uri(RoseWebview *view, const char *uri)
 {
 	if (!has_prefix(uri)) {
 		char tmp[254];
-		sprintf(tmp, "https://duckduckgo.com/?q=%s", uri);
+		snprintf(tmp, sizeof(tmp) - 1, "https://duckduckgo.com/?q=%s", uri);
 		webkit_web_view_load_uri(view->webview, tmp);
 		return;
 	}
@@ -164,8 +166,10 @@ static RoseWebview *rose_webview_new(void)
 
 	if (!options[CACHE] && privacy[CACHING]) {
 		const char *HOME = getenv("HOME");
-		char *buf = calloc(1, sizeof(char) * (strlen(HOME) + 32) + 1);
-		sprintf(buf, "%s/.cache/rose/", HOME);
+		size_t bufsiz = sizeof(char) * (strlen(HOME) + 32) + 1;
+		char *buf = calloc(1, bufsiz);
+
+		snprintf(buf, bufsiz - 1, "%s/.cache/rose/", HOME);
 		options[CACHE] = buf;
 	}
 
@@ -241,9 +245,9 @@ static void append_history(const char *uri)
 {
 		char *cookiefile;
 		FILE *cookie;
-		cookiefile= calloc(1,
-		                   sizeof(char) * (strlen(options[CACHE]) + 32) + 1);
-		sprintf(cookiefile, "%s/history", options[CACHE]);
+		size_t bufsiz = sizeof(char) * (strlen(options[CACHE]) + 32) + 1;
+		cookiefile= calloc(1, bufsiz);
+		snprintf(cookiefile, bufsiz - 1, "%s/history", options[CACHE]);
 		cookie = fopen(cookiefile, "a");
 		fprintf(cookie, "%s\n", uri);
 		fclose(cookie);

--- a/rose.c
+++ b/rose.c
@@ -129,7 +129,7 @@ static void rose_download(const char* filename, const char *uri)
 	int id = fork();
 	if (id == 0) {
 		setsid();
-		execlp("aria2c", "aria2c", uri, NULL);
+		execlp("aria2c", "aria2c", uri, (char *)NULL);
 		perror(" failed");
 		exit(1);
 	}


### PR DESCRIPTION
- sprintf can lead to buffer overflow
- other minor tweaks