### PR TITLE
Remove bash-only features for sh scripts

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,15 +1,15 @@
-#!/bin/bash
+#!/bin/sh
 
 CC=clang
 SRC=rose.c
 REQS= #./plugins/*/*.c
-DEPS=('webkit2gtk-4.0')
+DEPS='webkit2gtk-4.0'
 
-INCS=`pkg-config --cflags ${DEPS[@]}`
-LIBS=`pkg-config --libs ${DEPS[@]}`
+INCS=`pkg-config --cflags ${DEPS}`
+LIBS=`pkg-config --libs ${DEPS}`
 
 # Optional adblocking depends on https://github.com/jun7/wyebadblock
 WYEBAB='-L/usr/lib/wyebrowser/adblock.so'
 
 cp -f config.def.h config.h
-$CC $INCS $LIBS $REQS $SRC $WYEBAB -o rose
+$CC $INCS $REQS $SRC -o rose $LIBS $WYEBAB

--- a/rose-mklink
+++ b/rose-mklink
@@ -1,8 +1,8 @@
-#!/bin/bash
+#!/bin/sh
 
 test "$1" = "--help" || test -z "$1" && {
-	echo -e "usage: rose-mklink <alias> <url>\n"
-	echo "Create a /usr/bin link to a website."
+    printf "%s\n" "usage: rose-mklink <alias> <url>" \
+        "Create a /usr/bin link to a website."
 	exit
 }
 
@@ -12,6 +12,6 @@ test -z "$2" || {
 		exit 1
 	}
 
-	echo -e "#!/bin/sh\n\nrose $2" > /usr/bin/$1
+	printf "#!/bin/sh\n\nrose %s" "$2" > /usr/bin/$1
 	chmod +x /usr/bin/$1
 }


### PR DESCRIPTION
Usage of a bash array isnt really necessary as just a whitespace separated string of elements would work just as well, removing the need for bash as a make dependency. 
Use of printf is prefered over echo -e for the same reason.

Fix order of CC arguments to aid in linking on newer versions, had some issues with clang 15.0.7 on musl failing to link with the previous order of arguments.